### PR TITLE
Fix in XLSX parser

### DIFF
--- a/SpreadsheetReader.php
+++ b/SpreadsheetReader.php
@@ -4,7 +4,7 @@
  * TODO:
  * - XLSX XML parsing suffers from a Shliemel the painter problem (sharedStrings.xml)
  *
- * @version 0.3.3
+ * @version 0.3.4
  * @author Martins Pilsetnieks
  */
 	class SpreadsheetReader implements Iterator, Countable

--- a/SpreadsheetReader_XLSX.php
+++ b/SpreadsheetReader_XLSX.php
@@ -839,7 +839,7 @@
 				}
 				else
 				{
-					$this -> CurrentRow = [];
+					$this -> CurrentRow = array();
 				}
 
 				// These two are needed to control for empty cells


### PR DESCRIPTION
Fix in XLSX parser, "[]" was used instead of "array()" thus making it
incompatible with PHP 5.3.0
