### PR TITLE
Changed XLS UTF-16 decoder

### DIFF
--- a/SpreadsheetReader_XLS.php
+++ b/SpreadsheetReader_XLS.php
@@ -54,6 +54,12 @@
 
 			$this -> Handle = new Spreadsheet_Excel_Reader;
 			$this -> Handle -> setOutputEncoding('UTF-8');
+
+			if (function_exists('mb_convert_encoding'))
+			{
+				$this -> Handle -> setUTFEncoder('mb');
+			}
+
 			$this -> Handle -> read($Filepath);
 			if (empty($this -> Handle -> sheets))
 			{


### PR DESCRIPTION
Changed UTF-16 decoder for XLS files to PHP's mbstring extension, if
available (iconv is used by default).
