### PR TITLE
Fix for unset timezones

### DIFF
--- a/SpreadsheetReader.php
+++ b/SpreadsheetReader.php
@@ -44,6 +44,13 @@
 				throw new Exception('SpreadsheetReader: File ('.$Filepath.') not readable');
 			}
 
+			// To avoid timezone warnings and exceptions for formatting dates retrieved from files
+			$DefaultTZ = @date_default_timezone_get();
+			if ($DefaultTZ)
+			{
+				date_default_timezone_set($DefaultTZ);
+			}
+
 			// 1. Determine type
 			if (!$OriginalFilename)
 			{


### PR DESCRIPTION
If the timezone is not set, DateTime object in the XLSX parser threw an exception about it
