### PR TITLE
Fix ChangeSheet in SpreadsheetReader_XLSX.php

### DIFF
--- a/SpreadsheetReader_XLSX.php
+++ b/SpreadsheetReader_XLSX.php
@@ -406,6 +406,12 @@
 			if ($RealSheetIndex !== false && is_readable($TempWorksheetPath))
 			{
 				$this -> WorksheetPath = $TempWorksheetPath;
+				if ($this -> Worksheet instanceof XMLReader)
+				{
+                                    $this -> Worksheet -> close();
+                                }
+                                $this -> Worksheet = null;
+				
 				$this -> rewind();
 				return true;
 			}


### PR DESCRIPTION
Calling ChangeSheet didnt work if the instance existed previously, added a call to close and also set the Worksheet to null so the rewind() function actually opens the temp file that contains the selected sheet data.