### PR TITLE
Added the possibility of computing the values of merged cells

### DIFF
--- a/SpreadsheetReader.php
+++ b/SpreadsheetReader.php
@@ -36,8 +36,9 @@
 		 * @param string Path to file
 		 * @param string Original filename (in case of an uploaded file), used to determine file type, optional
 		 * @param string MIME type from an upload, used to determine file type, optional
+		 * @param bool Set to true allow for merged cells processing. Slower and less memory efficient but actually gives the right values in the lower merged cells.
 		 */
-		public function __construct($Filepath, $OriginalFilename = false, $MimeType = false)
+		public function __construct($Filepath, $OriginalFilename = false, $MimeType = false, $ProcessMerge = false)
 		{
 			if (!is_readable($Filepath))
 			{
@@ -151,7 +152,7 @@
 			{
 				case self::TYPE_XLSX:
 					self::Load(self::TYPE_XLSX);
-					$this -> Handle = new SpreadsheetReader_XLSX($Filepath);
+					$this -> Handle = new SpreadsheetReader_XLSX($Filepath, array("ProcessMerge" => $ProcessMerge));
 					break;
 				case self::TYPE_CSV:
 					self::Load(self::TYPE_CSV);

--- a/SpreadsheetReader_XLSX.php
+++ b/SpreadsheetReader_XLSX.php
@@ -103,6 +103,21 @@
 		private $SSOpen = false;
 		private $SSForwarded = false;
 
+		/**
+		 * @var string List of all merged cells in this worksheet
+		 */ 
+		private $MergedCells = "";
+
+		/**
+		 * @var array Index of all the top values of the merged cells
+		 */ 
+		private $RangeValues = array();
+
+		/**
+		 * @var bool Option on whether or not processing the merged cells
+		 */ 
+		private $ProcessMerge = null ;
+
 		private static $BuiltinFormats = array(
 			1 => '0',
 			2 => '0.00',
@@ -197,7 +212,8 @@
 		 * @param string Path to file
 		 * @param array Options:
 		 *	TempDir => string Temporary directory path
-		 *	ReturnDateTimeObjects => bool True => dates and times will be returned as PHP DateTime objects, false => as strings
+		 *	ReturnDateTimeObjects => bool True => dates and times will be returned as PHP DateTime objects, false => as strings,
+		 *  ProcessMerge => bool True => try to retrieve the values for merged cells (really slower and less memory efficient), false => don't try. It's quick and light on memory.
 		 */
 		public function __construct($Filepath, array $Options = null)
 		{
@@ -212,6 +228,8 @@
 
 			$this -> TempDir = rtrim($this -> TempDir, DIRECTORY_SEPARATOR);
 			$this -> TempDir = $this -> TempDir.DIRECTORY_SEPARATOR.uniqid().DIRECTORY_SEPARATOR;
+
+			$this -> ProcessMerge = $Options['ProcessMerge'];
 
 			$Zip = new ZipArchive;
 			$Status = $Zip -> open($Filepath);
@@ -407,10 +425,84 @@
 			{
 				$this -> WorksheetPath = $TempWorksheetPath;
 				$this -> rewind();
+				if($this -> ProcessMerge){
+					$this -> parseMergedCells();
+					$this -> rewind();
+				}	
 				return true;
 			}
 
 			return false;
+		}
+
+		/**
+		 * Do a first sweep of the worksheet to detect merged cells and keep the ranges in memory
+		 */
+		private function parseMergedCells(){
+			$this -> Index++;
+
+			$this -> CurrentRow = array();
+
+			if (!$this -> RowOpen)
+			{
+				while ($this -> Valid = $this -> Worksheet -> read())
+				{
+					if( $this -> Worksheet -> name == "mergeCell" ){
+						$MergeSpans = $this -> Worksheet -> getAttribute('ref');
+
+						if($MergeSpans){
+							$MergeSpans = explode(':', $MergeSpans);
+							$RowIndex = $MergeEnd = $ColumnIndex = $x = 0 ;
+							preg_match('/\d+/', $MergeSpans[0], $RowIndex);
+							preg_match('/\d+/', $MergeSpans[1], $MergeEnd);
+							preg_match('/\D+/', $MergeSpans[0], $ColumnIndex);
+							while($RowIndex[0] < $MergeEnd[0]){
+								$RowIndex[0] ++ ;
+								$x ++ ;
+								$MergeSpans[$x] = $ColumnIndex[0].$RowIndex[0];
+							}
+							$this -> MergedCells .= implode(':', $MergeSpans) . "|" ;
+						}
+					}
+				}
+			}
+		}
+
+		/**
+		 * Check against the index whether or not a cell is merged
+		 *
+		 * @param string The name of the cell (A5, C49, AK954, ...)
+		 *
+		 * @return int 1 if cell is merged, otherwise 0.
+		 */
+		private function isMerged($cellReference){
+			return preg_match("/(\||\:)($cellReference)(\||\:)/", $this -> MergedCells);
+		}
+
+		/**
+		 * Gives the range in which the given cell is situated
+		 *
+		 * @param string The name of the cell (A5, C49, AK954, ...)
+		 *
+		 * @return string the complete range definition
+		 */
+		private function mergedRange($cellReference){
+			$range = "";
+			preg_match("/(\||^)((\w+:)+)?($cellReference)(:(\w+:?)+|\|)/i", $this -> MergedCells, $range);
+			return trim($range[0], "|");
+		}
+
+		/**
+		 * Gives the value of the top cell in the range
+		 *
+		 * @param string the range you want to know the value of
+		 *
+		 * @return mixed the range value
+		 */
+		private function mergedValue($range){
+			$range = explode(':', $range);
+			$first = $range[0];
+			return $this -> RangeValues[$first]?: false;
 		}
 
 		/**
@@ -998,6 +1090,7 @@
 				$CellCount = 0;
 
 				$CellHasSharedString = false;
+				$CellIsMerged = $CellName = $MergedRange = $MergedValue = false;
 
 				while ($this -> Valid = $this -> Worksheet -> read())
 				{
@@ -1013,7 +1106,7 @@
 							break;
 						// Cell
 						case 'c':
-							// If it is a closing tag, skip it
+							// If it is a closing tag, skip it, unless it's merged
 							if ($this -> Worksheet -> nodeType == XMLReader::END_ELEMENT)
 							{
 								continue;
@@ -1037,6 +1130,12 @@
 							}
 
 							$this -> CurrentRow[$Index] = '';
+							$CellName = $this -> Worksheet -> getAttribute('r');
+							$CellIsMerged = $this -> isMerged($CellName);
+							if( $CellIsMerged ){
+								$MergedValue = $this -> mergedValue($this -> mergedRange($CellName));
+								$this -> CurrentRow[$Index] = $MergedValue;
+							}
 
 							$CellCount++;
 							if ($Index > $MaxIndex)
@@ -1066,6 +1165,11 @@
 							}
 
 							$this -> CurrentRow[$Index] = $Value;
+
+							if($CellIsMerged){
+								$this -> RangeValues[$CellName] = $Value;
+							}
+
 							break;
 					}
 				}


### PR DESCRIPTION
Hello, following my own issue at https://github.com/nuovo/spreadsheet-reader/issues/77 , I decided to tackle the issue on my own.

Here's my proposal for that. 

I added a few function into the XSLX parser in order to index, save and retrieve values of merged cells. I couldn't find a way to do it more efficiently than that without making a massive reworking of the library. Changes in performance are about tenfold (but I was working with a huge file, with lots and lots of merged cells, so I suppose it would be faster with a smaller file). 
If you don't mind waiting about 2 seconds for PHP to process everything, it's worth it. The memory usage increase is around 2-5%.

So, yeah, adding merged cells processing takes a lot more time and memory than without. It does however allow completely transparent values in the range. 

To activate this option, simply call the reader like you would do usually, but add the parameter at the end like that :

``` php
$Spreadsheet = new SpreadsheetReader($Filepath, false, false, true);
```
