### PR TITLE
moved files and directory deletion at the end of destructor, after…

### DIFF
--- a/SpreadsheetReader_XLSX.php
+++ b/SpreadsheetReader_XLSX.php
@@ -321,19 +321,6 @@
 		 */
 		public function __destruct()
 		{
-			foreach ($this -> TempFiles as $TempFile)
-			{
-				@unlink($TempFile);
-			}
-
-			// Better safe than sorry - shouldn't try deleting '.' or '/', or '..'.
-			if (strlen($this -> TempDir) > 2)
-			{
-				@rmdir($this -> TempDir.'xl'.DIRECTORY_SEPARATOR.'worksheets');
-				@rmdir($this -> TempDir.'xl');
-				@rmdir($this -> TempDir);
-			}
-
 			if ($this -> Worksheet && $this -> Worksheet instanceof XMLReader)
 			{
 				$this -> Worksheet -> close();
@@ -355,6 +342,19 @@
 			if ($this -> WorkbookXML)
 			{
 				unset($this -> WorkbookXML);
+			}
+
+			foreach ($this -> TempFiles as $TempFile)
+			{
+				@unlink($TempFile);
+			}
+
+			// Better safe than sorry - shouldn't try deleting '.' or '/', or '..'.
+			if (strlen($this -> TempDir) > 2)
+			{
+				@rmdir($this -> TempDir.'xl'.DIRECTORY_SEPARATOR.'worksheets');
+				@rmdir($this -> TempDir.'xl');
+				@rmdir($this -> TempDir);
 			}
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "nuovo/spreadsheet-reader",
+	"name": "pa-m/spreadsheet-reader",
 	"description": "Spreadsheet reader library for Excel, OpenOffice and structured text files",
 	"keywords": ["spreadsheet", "xls", "xlsx", "ods", "csv", "excel", "openoffice"],
 	"homepage": "https://github.com/nuovo/spreadsheet-reader",


### PR DESCRIPTION
Hi,
I moved files and directory deletion at the end of destructor, after XmlReaders desctruction, to avoid them to lock the temporary files and crash on unlink call.
Best regards
