### PR TITLE
Detect mime type application/zip as a XLSX file

### DIFF
--- a/SpreadsheetReader.php
+++ b/SpreadsheetReader.php
@@ -106,6 +106,7 @@
 				case 'application/vnd.openxmlformats-officedocument.spreadsheetml.template':
 				case 'application/xlsx':
 				case 'application/xltx':
+				case 'application/zip':
 					$this -> Type = self::TYPE_XLSX;
 					break;
 				case 'application/xml':


### PR DESCRIPTION
XLSX files with an application/zip mime type aren't handle by the parser. Add this mime type to detect as a XLSX file.