### PR TITLE
Fixed scientific notation bug when reading OBS sheets.

### DIFF
--- a/SpreadsheetReader_ODS.php
+++ b/SpreadsheetReader_ODS.php
@@ -286,7 +286,13 @@
 							}
 							else
 							{
-								$LastCellContent = '';
+								// If there is an office value for this cell use that instead of what is actually in the cell; stops formating errors like incorrect scientific notation
+								if ($this -> Content -> getAttribute('office:value') !== null)
+								{
+									$LastCellContent = $this -> Content -> getAttribute('office:value');
+								} else {
+									$LastCellContent = '';
+								}
 							}
 						case 'text:p':
 							if ($this -> Content -> nodeType != XMLReader::END_ELEMENT)


### PR DESCRIPTION
**Scientific Notation Bug / Format Bugs:**
Many OBS applications save cells with long numbers in a loose scientific notation format, this means any cell with a long, float, or double length number will be transformed into a relatively close but not correct scientific notation. 

**Example:** 
`612205820123` becomes `6.12206E+11` but so does any number of the same length if it starts with `6122058`. This effectually destroys tracking numbers that do not include letters for example (FedEx).

**Easy Solution**:
The real number is saved as an `office:value` attribute attached to the table cell. If a `office:value` attribute is found on a table cell we simply need to use that value instead to avoid format bugs like this one; as well as any other bugs I may not have found yet, after all they (the OBS standards people) created the `office:value` attribute for a reason.

**PS:**
@nuovo - It seems pull request are going unanswered. I don't mind taking over this repo if you don't have time?