### PR TITLE
checking if the col value is actual number. avoid digital string with leading zeros dropped

### DIFF
--- a/SpreadsheetReader_XLSX.php
+++ b/SpreadsheetReader_XLSX.php
@@ -929,7 +929,7 @@
 		public function GeneralFormat($Value)
 		{
 			// Numeric format
-			if (is_numeric($Value))
+            if (is_numeric($Value) && preg_match('/^(?:-)?([1-9]|(0\.))/', $Value))
 			{
 				$Value = (float)$Value;
 			}


### PR DESCRIPTION
checking if the col value is actual number. avoid digital string with leading zeros dropped

e.g.  

col value  0000189810 was converted to 189810
