### PR TITLE
Fatal error: Uncaught ValueError: XMLReader::open(): Argument #1 ($uri) cannot be empty

### DIFF
--- a/SpreadsheetReader_XLSX.php
+++ b/SpreadsheetReader_XLSX.php
@@ -370,12 +370,12 @@
 				$this -> Sheets = array();
 				foreach ($this -> WorkbookXML -> sheets -> sheet as $Index => $Sheet)
 				{
-					$Attributes = $Sheet -> attributes('r', true);
+					$Attributes = $Sheet -> attributes();
 					foreach ($Attributes as $Name => $Value)
 					{
-						if ($Name == 'id')
+						if ($Name == 'sheetId')
 						{
-							$SheetID = (int)str_replace('rId', '', (string)$Value);
+							$SheetID = (int)$Value;
 							break;
 						}
 					}


### PR DESCRIPTION
When users download XLSX from Google Sheets in xl\workbook.xml we see next items:
`<sheet name="Sheet 1" sheetId="1" state="visible" r:id="rId2"/>`
When we open this file and save in Office Excel its convert to:
`<sheet name="Sheet 1" sheetId="1" r:id="rId1"/>`